### PR TITLE
add public course listing with cards and loading skeleton

### DIFF
--- a/app/(public)/_components/public-course-card.tsx
+++ b/app/(public)/_components/public-course-card.tsx
@@ -1,0 +1,98 @@
+import Image from "next/image";
+import Link from "next/link";
+import { SchoolIcon, TimerIcon } from "lucide-react";
+
+import { GetAllCourses } from "@/app/data/course/get-all-courses";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { useConstructUrl } from "@/hooks/use-construct-url";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PublicCourseCardProps {
+  data: GetAllCourses[number];
+}
+
+export const PublicCourseCard = ({ data }: PublicCourseCardProps) => {
+  const thumbnailUrl = useConstructUrl(data.fileKey);
+
+  return (
+    <Card className="group relative gap-0 py-0">
+      <Badge className="absolute top-2 right-2 z-10">{data.level}</Badge>
+
+      <Image
+        src={thumbnailUrl}
+        width={600}
+        height={400}
+        alt="thumbnail image"
+        className="aspect-video size-full rounded-t-xl object-cover"
+      />
+
+      <CardContent className="p-4">
+        <Link
+          href={`/courses/${data.slug}`}
+          className="group-hover:text-primary line-clamp-2 text-lg font-medium transition-colors hover:underline"
+        >
+          {data.title}
+        </Link>
+
+        <p className="text-muted-foreground mt-2 line-clamp-2 text-sm leading-tight">
+          {data.smallDescription}
+        </p>
+
+        <div className="mt-4 flex items-center gap-x-5">
+          <div className="flex items-center gap-x-2">
+            <TimerIcon className="text-primary bg-primary/10 size-6 rounded-md p-1" />
+            <p className="text-muted-foreground text-sm">{data.duration}h</p>
+          </div>
+          <div className="flex items-center gap-x-2">
+            <SchoolIcon className="text-primary bg-primary/10 size-6 rounded-md p-1" />
+            <p className="text-muted-foreground text-sm">{data.category}</p>
+          </div>
+        </div>
+
+        <Link
+          href={`/courses/${data.slug}`}
+          className={buttonVariants({ className: "mt-4 w-full" })}
+        >
+          Learn More
+        </Link>
+      </CardContent>
+    </Card>
+  );
+};
+
+export function PublicCourseCardSkeleton() {
+  return (
+    <Card className="group relative gap-0 py-0">
+      <div className="absolute top-2 right-2 z-10 flex items-center">
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+
+      <div className="relative h-fit w-full">
+        <Skeleton className="aspect-video w-full rounded-t-xl" />
+      </div>
+
+      <CardContent className="p-4">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+
+        <div className="mt-4 flex items-center gap-x-5">
+          <div className="flex items-center gap-x-2">
+            <Skeleton className="size-6 rounded-md" />
+            <Skeleton className="h-4 w-8" />
+          </div>
+
+          <div className="flex items-center gap-x-2">
+            <Skeleton className="size-6 rounded-md" />
+            <Skeleton className="h-4 w-8" />
+          </div>
+        </div>
+
+        <Skeleton className="mt-4 h-10 w-full rounded-md" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(public)/courses/page.tsx
+++ b/app/(public)/courses/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+
+import { getAllCourses } from "@/app/data/course/get-all-courses";
+
+import {
+  PublicCourseCard,
+  PublicCourseCardSkeleton,
+} from "../_components/public-course-card";
+
+const PublicCoursesPage = () => {
+  return (
+    <div className="mt-5">
+      <div className="mb-10 flex flex-col gap-y-2">
+        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+          Explore Courses
+        </h1>
+        <p className="text-muted-foreground">
+          Discover our wide range of courses designed to help you achieve your
+          goals.
+        </p>
+      </div>
+
+      <Suspense fallback={<LoadingSkeletonLayout />}>
+        <RenderCourses />
+      </Suspense>
+    </div>
+  );
+};
+
+async function RenderCourses() {
+  const courses = await getAllCourses();
+
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {courses.map((course) => (
+        <PublicCourseCard key={course.id} data={course} />
+      ))}
+    </div>
+  );
+}
+
+function LoadingSkeletonLayout() {
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 9 }).map((_, index) => (
+        <PublicCourseCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+export default PublicCoursesPage;

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -4,7 +4,9 @@ const PublicLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div>
       <Navbar />
-      <main className="container mx-auto px-4 md:px-6 lg:px-8">{children}</main>
+      <main className="container mx-auto mb-32 px-4 md:px-6 lg:px-8">
+        {children}
+      </main>
     </div>
   );
 };

--- a/app/data/course/get-all-courses.ts
+++ b/app/data/course/get-all-courses.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+
+export async function getAllCourses() {
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
+  const data = await prisma.course.findMany({
+    where: {
+      status: "Published",
+    },
+    select: {
+      title: true,
+      price: true,
+      smallDescription: true,
+      fileKey: true,
+      id: true,
+      slug: true,
+      level: true,
+      duration: true,
+      category: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return data;
+}
+
+export type GetAllCourses = Awaited<ReturnType<typeof getAllCourses>>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a public Courses page displaying published courses in a responsive grid.
  * Added course cards with thumbnail, title, short description, level, duration, category, and a “Learn More” link.
  * Implemented a loading experience with skeleton placeholders while course data loads.

* **Style**
  * Increased bottom spacing in the public layout to improve page spacing and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->