### PR TITLE
add lesson skeleton and course progress

### DIFF
--- a/app/dashboard/[slug]/[lessonId]/_components/lesson-skeleton.tsx
+++ b/app/dashboard/[slug]/[lessonId]/_components/lesson-skeleton.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface LessonSkeletonProps {}
+
+export const LessonSkeleton = ({}: LessonSkeletonProps) => {
+  return (
+    <div className="flex h-full flex-col pl-6">
+      <div className="bg-muted relative aspect-video overflow-hidden rounded-lg">
+        <Skeleton className="size-full" />
+      </div>
+
+      <div className="flex-1 space-y-6">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-4/6" />
+        </div>
+
+        <div className="flex gap-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-5/24" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/dashboard/[slug]/[lessonId]/page.tsx
+++ b/app/dashboard/[slug]/[lessonId]/page.tsx
@@ -1,6 +1,9 @@
+import { Suspense } from "react";
+
 import { getLessonContent } from "@/app/data/course/get-lesson-content";
 
 import { CourseContent } from "../[lessonId]/_components/course-content";
+import { LessonSkeleton } from "../[lessonId]/_components/lesson-skeleton";
 
 interface CourseSlugLessonIdPageProps {
   params: Promise<{ lessonId: string }>;
@@ -10,9 +13,18 @@ const CourseSlugLessonIdPage = async ({
   params,
 }: CourseSlugLessonIdPageProps) => {
   const { lessonId } = await params;
-  const data = await getLessonContent(lessonId);
 
-  return <CourseContent data={data} />;
+  return (
+    <Suspense fallback={<LessonSkeleton />}>
+      <LessonContentLoader lessonId={lessonId} />
+    </Suspense>
+  );
 };
 
 export default CourseSlugLessonIdPage;
+
+async function LessonContentLoader({ lessonId }: { lessonId: string }) {
+  const data = await getLessonContent(lessonId);
+
+  return <CourseContent data={data} />;
+}

--- a/app/dashboard/[slug]/page.tsx
+++ b/app/dashboard/[slug]/page.tsx
@@ -1,5 +1,31 @@
-const CourseSlugPage = () => {
-  return <div>CourseSlugPage</div>;
+import { redirect } from "next/navigation";
+
+import { getCourseSidebarData } from "@/app/data/course/get-course-sidebar-data";
+
+interface CourseSlugPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const CourseSlugPage = async ({ params }: CourseSlugPageProps) => {
+  const { slug } = await params;
+
+  const course = await getCourseSidebarData(slug);
+
+  const firstChapter = course.chapter[0];
+  const firstLesson = firstChapter.lessons[0];
+
+  if (firstLesson) {
+    redirect(`/dashboard/${slug}/${firstLesson.id}`);
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center text-center">
+      <h2 className="mb-2 text-2xl font-bold">No lessons available</h2>
+      <p className="text-muted-foreground">
+        This course does not have any lessons yet. Please check back later.
+      </p>
+    </div>
+  );
 };
 
 export default CourseSlugPage;

--- a/app/dashboard/_components/course-progress-card.tsx
+++ b/app/dashboard/_components/course-progress-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { useConstructUrl } from "@/hooks/use-construct-url";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EnrolledCourseType } from "@/app/data/user/get-enrolled-courses";
+import { useCourseProgress } from "@/hooks/use-course-progress";
+import { Progress } from "@/components/ui/progress";
+
+interface PublicCourseCardProps {
+  data: EnrolledCourseType;
+}
+
+export const CourseProgressCard = ({ data }: PublicCourseCardProps) => {
+  const thumbnailUrl = useConstructUrl(data.Course.fileKey);
+  const { totalLessons, completedLessons, progressPercentage } =
+    useCourseProgress({
+      courseData: data.Course as any,
+    });
+
+  return (
+    <Card className="group relative gap-0 py-0">
+      <Badge className="absolute top-2 right-2 z-10">{data.Course.level}</Badge>
+
+      <Image
+        src={thumbnailUrl}
+        width={600}
+        height={400}
+        alt="thumbnail image"
+        className="aspect-video size-full rounded-t-xl object-cover"
+      />
+
+      <CardContent className="p-4">
+        <Link
+          href={`/dashboard/${data.Course.slug}`}
+          className="group-hover:text-primary line-clamp-2 text-lg font-medium transition-colors hover:underline"
+        >
+          {data.Course.title}
+        </Link>
+
+        <p className="text-muted-foreground mt-2 line-clamp-2 text-sm leading-tight">
+          {data.Course.smallDescription}
+        </p>
+
+        <div className="mt-5 space-y-4">
+          <div className="mb-1 flex justify-between text-sm">
+            <p>Progress:</p>
+            <p className="font-medium">{progressPercentage}%</p>
+          </div>
+
+          <Progress value={progressPercentage} className="h-1.5" />
+
+          <p className="text-muted-foreground mt-1 text-xs">
+            {completedLessons} of {totalLessons} lessons completed
+          </p>
+        </div>
+
+        <Link
+          href={`/dashboard/${data.Course.slug}`}
+          className={buttonVariants({ className: "mt-4 w-full" })}
+        >
+          Learn More
+        </Link>
+      </CardContent>
+    </Card>
+  );
+};
+
+export function PublicCourseCardSkeleton() {
+  return (
+    <Card className="group relative gap-0 py-0">
+      <div className="absolute top-2 right-2 z-10 flex items-center">
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+
+      <div className="relative h-fit w-full">
+        <Skeleton className="aspect-video w-full rounded-t-xl" />
+      </div>
+
+      <CardContent className="p-4">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+
+        <div className="mt-4 flex items-center gap-x-5">
+          <div className="flex items-center gap-x-2">
+            <Skeleton className="size-6 rounded-md" />
+            <Skeleton className="h-4 w-8" />
+          </div>
+
+          <div className="flex items-center gap-x-2">
+            <Skeleton className="size-6 rounded-md" />
+            <Skeleton className="h-4 w-8" />
+          </div>
+        </div>
+
+        <Skeleton className="mt-4 h-10 w-full rounded-md" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,8 +1,8 @@
 import { PublicCourseCard } from "@/app/(public)/_components/public-course-card";
+import { CourseProgressCard } from "@/app/dashboard/_components/course-progress-card";
 import { getAllCourses } from "@/app/data/course/get-all-courses";
 import { getEnrolledCourses } from "@/app/data/user/get-enrolled-courses";
 import { EmptyState } from "@/components/general/empty-state";
-import Link from "next/link";
 
 const DashboardPage = async () => {
   const [courses, enrolledCourses] = await Promise.all([
@@ -36,12 +36,7 @@ const DashboardPage = async () => {
       ) : (
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {enrolledCourses.map((course) => (
-            <Link
-              key={course.Course.id}
-              href={`/dashboard/${course.Course.slug}`}
-            >
-              {course.Course.title}
-            </Link>
+            <CourseProgressCard key={course.Course.id} data={course} />
           ))}
         </div>
       )}

--- a/app/data/user/get-enrolled-courses.ts
+++ b/app/data/user/get-enrolled-courses.ts
@@ -28,6 +28,16 @@ export async function getEnrolledCourses() {
               lessons: {
                 select: {
                   id: true,
+                  lessonProgress: {
+                    where: {
+                      userId: user.id,
+                    },
+                    select: {
+                      id: true,
+                      completed: true,
+                      lessonId: true,
+                    },
+                  },
                 },
               },
             },
@@ -39,3 +49,7 @@ export async function getEnrolledCourses() {
 
   return data;
 }
+
+export type EnrolledCourseType = Awaited<
+  ReturnType<typeof getEnrolledCourses>
+>[number];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now shows a Course Progress Card with thumbnail, level, description, progress bar, and completion stats, plus a matching loading skeleton.
  * Lesson pages display a skeleton loader while content is fetched.

* **Improvements**
  * Visiting a course route now auto-redirects to the first available lesson; if none exist, a clear “No lessons available” message is shown.
  * Enrolled courses list updated to use the new card, presenting progress based on your completed lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->